### PR TITLE
fix(stat_cech2): correct & refactor proximate_triples() + update examples, tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,5 +38,5 @@ Suggests:
     rmarkdown (>= 1.10),
     covr (>= 3.1.0)
 VignetteBuilder: knitr
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)

--- a/R/simplicial-complex.R
+++ b/R/simplicial-complex.R
@@ -483,8 +483,3 @@ GeomFace <- ggproto(
   default_aes = aes(colour = "NA", fill = "grey", alpha = .15,
                     size = 0.5, linetype = 1)
 )
-
-acos_tol <- function(x, tol = sqrt(.Machine$double.eps)) {
-  x <- ifelse(abs(x) > 1 + tol, x, pmin(pmax(x, -1), 1))
-  acos(x)
-}

--- a/R/simplicial-complex.R
+++ b/R/simplicial-complex.R
@@ -385,7 +385,7 @@ StatCech2 <- ggproto(
     }
     
     # indices of triples of data points that are within `diameter` of some point
-    faces <- as.data.frame(proximate_triples(data, diameter))
+    faces <- proximate_triples(data, diameter)
     faces <- t(as.matrix(faces))[c("a", "b", "c"), , drop = FALSE]
     
     # data frame of faces' perimeter coordinates
@@ -414,7 +414,8 @@ proximate_triples <- function(data, diameter) {
     b = unlist(lapply(2:nrow(data), function(k) k:nrow(data))),
     d = as.vector(stats::dist(data))
   )
-  dists <- dists[dists$d < diameter, ]
+  # shed too-distant pairs
+  dists <- dists[dists$d < diameter, , drop = FALSE]
   # distances among triples
   triples <- merge(
     dists,
@@ -426,43 +427,24 @@ proximate_triples <- function(data, diameter) {
     transform(dists, c = dists$b, b = NULL, d_ac = dists$d, d = NULL),
     by = c("a", "c")
   )
-  # triples within `diameter` of each other -> circumdiameter
-  triples$s <- (triples$d_ab + triples$d_bc + triples$d_ac) / 2
-  triples$cd <- 2 * triples$d_ab * triples$d_bc * triples$d_ac / sqrt(
+  # semiperimeters
+  triples$s <- .5 * (triples$d_ab + triples$d_bc + triples$d_ac)
+  # circumdiameters
+  triples$cd <- .5 * triples$d_ab * triples$d_bc * triples$d_ac / sqrt(
     triples$s * (triples$s - triples$d_ab) *
       (triples$s - triples$d_bc) * (triples$s - triples$d_ac)
   )
-  # vectors between pairs
-  triples <- transform(
-    triples,
-    x_ab = data$x[triples$b] - data$x[triples$a],
-    y_ab = data$y[triples$b] - data$y[triples$a],
-    x_bc = data$x[triples$c] - data$x[triples$b],
-    y_bc = data$y[triples$c] - data$y[triples$b],
-    x_ac = data$x[triples$c] - data$x[triples$a],
-    y_ac = data$y[triples$c] - data$y[triples$a]
-  )
-  # inner products of vectors within triples
-  triples <- transform(
-    triples,
-    d_a = triples$x_ab * triples$x_ac + triples$y_ab * triples$y_ac,
-    d_b = triples$x_ab * triples$x_bc + triples$y_ab * triples$y_bc,
-    d_c = triples$x_ac * triples$x_bc + triples$y_ac * triples$y_bc
-  )
-  # angles among triples
-  triples <- transform(
-    triples,
-    t_a = acos_tol(triples$d_a / (triples$d_ab * triples$d_ac), 1e-7),
-    t_b = acos_tol(triples$d_b / (triples$d_ab * triples$d_bc), 1e-7),
-    t_c = acos_tol(triples$d_c / (triples$d_ac * triples$d_bc), 1e-7)
-  )
-  # if any angle is obtuse, longest side length; otherwise, circumdiameter
+  # squares of longest sides
+  triples$m <- pmax(triples$d_ab, triples$d_bc, triples$d_ac)^2
+  # sum of squares of remaining sides
+  triples$n <- triples$d_ab^2 + triples$d_bc^2 + triples$d_ac^2 - triples$m
+  # when largest angles obtuse, longest side lengths; otherwise, circumdiameters
   triples$diam <- ifelse(
-    pmax(triples$t_a, triples$t_b, triples$t_c) > pi/2,
+    triples$m > triples$n,
     pmax(triples$d_ab, triples$d_bc, triples$d_ac),
     triples$cd
   )
-  triples <- triples[triples$diam < diameter, c("a", "b", "c")]
+  triples <- triples[triples$diam < diameter, c("a", "b", "c"), drop = FALSE]
   rownames(triples) <- NULL
   triples
 }

--- a/inst/examples/ex-simplicial-complex.R
+++ b/inst/examples/ex-simplicial-complex.R
@@ -10,59 +10,60 @@ make_noisy_circle <- function(n, sd = .01) {
 # generate a noisy 2D circle
 set.seed(1)
 d <- as.data.frame(make_noisy_circle(n = 40, sd = .15))
+r <- 1/3
 
 # plot balls beneath points
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_disk(radius = .35, fill = "aquamarine3") +
+  stat_disk(radius = r, fill = "aquamarine3") +
   geom_point()
 
 # plot Vietoris 1-skeleton
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_vietoris1(diameter = .7, alpha = .25) +
+  stat_vietoris1(diameter = 2*r, alpha = .25) +
   stat_vietoris0()
 
 # plot Vietoris 2-skeleton
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_vietoris2(diameter = .7, fill = "darkgoldenrod") +
-  stat_vietoris1(diameter = .7, alpha = .25) +
+  stat_vietoris2(diameter = 2*r, fill = "darkgoldenrod") +
+  stat_vietoris1(diameter = 2*r, alpha = .25) +
   stat_vietoris0()
 
 # plot Čech 2-skeleton
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_cech2(diameter = .7, fill = "darkgoldenrod") +
-  stat_cech1(diameter = .7, alpha = .25) +
+  stat_cech2(diameter = 2*r, fill = "darkgoldenrod") +
+  stat_cech1(diameter = 2*r, alpha = .25) +
   stat_cech0()
 
 # plot Vietoris 1-skeleton atop balls
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_disk(radius = .35, fill = "aquamarine3") +
-  stat_vietoris1(diameter = .7, size = .2) +
+  stat_disk(radius = r, fill = "aquamarine3") +
+  stat_vietoris1(diameter = 2*r, size = .2) +
   stat_vietoris0(size = .3)
 
 # plot Vietoris 2-skeleton atop balls
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_disk(radius = .35, fill = "aquamarine3") +
-  stat_vietoris2(diameter = .7, fill = "darkgoldenrod") +
-  stat_vietoris1(diameter = .7, size = .2) +
+  stat_disk(radius = r, fill = "aquamarine3") +
+  stat_vietoris2(diameter = 2*r, fill = "darkgoldenrod") +
+  stat_vietoris1(diameter = 2*r, size = .2) +
   stat_vietoris0(size = .3)
 
 # plot Čech 2-skeleton atop balls
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_disk(radius = .35, fill = "aquamarine3") +
-  stat_cech2(diameter = .7, fill = "darkgoldenrod") +
-  stat_cech1(diameter = .7, size = .2) +
+  stat_disk(radius = r, fill = "aquamarine3") +
+  stat_cech2(diameter = 2*r, fill = "darkgoldenrod") +
+  stat_cech1(diameter = 2*r, size = .2) +
   stat_cech0(size = .3)

--- a/man/simplicial-complex.Rd
+++ b/man/simplicial-complex.Rd
@@ -224,61 +224,62 @@ make_noisy_circle <- function(n, sd = .01) {
 # generate a noisy 2D circle
 set.seed(1)
 d <- as.data.frame(make_noisy_circle(n = 40, sd = .15))
+r <- 1/3
 
 # plot balls beneath points
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_disk(radius = .35, fill = "aquamarine3") +
+  stat_disk(radius = r, fill = "aquamarine3") +
   geom_point()
 
 # plot Vietoris 1-skeleton
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_vietoris1(diameter = .7, alpha = .25) +
+  stat_vietoris1(diameter = 2*r, alpha = .25) +
   stat_vietoris0()
 
 # plot Vietoris 2-skeleton
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_vietoris2(diameter = .7, fill = "darkgoldenrod") +
-  stat_vietoris1(diameter = .7, alpha = .25) +
+  stat_vietoris2(diameter = 2*r, fill = "darkgoldenrod") +
+  stat_vietoris1(diameter = 2*r, alpha = .25) +
   stat_vietoris0()
 
 # plot Čech 2-skeleton
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_cech2(diameter = .7, fill = "darkgoldenrod") +
-  stat_cech1(diameter = .7, alpha = .25) +
+  stat_cech2(diameter = 2*r, fill = "darkgoldenrod") +
+  stat_cech1(diameter = 2*r, alpha = .25) +
   stat_cech0()
 
 # plot Vietoris 1-skeleton atop balls
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_disk(radius = .35, fill = "aquamarine3") +
-  stat_vietoris1(diameter = .7, size = .2) +
+  stat_disk(radius = r, fill = "aquamarine3") +
+  stat_vietoris1(diameter = 2*r, size = .2) +
   stat_vietoris0(size = .3)
 
 # plot Vietoris 2-skeleton atop balls
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_disk(radius = .35, fill = "aquamarine3") +
-  stat_vietoris2(diameter = .7, fill = "darkgoldenrod") +
-  stat_vietoris1(diameter = .7, size = .2) +
+  stat_disk(radius = r, fill = "aquamarine3") +
+  stat_vietoris2(diameter = 2*r, fill = "darkgoldenrod") +
+  stat_vietoris1(diameter = 2*r, size = .2) +
   stat_vietoris0(size = .3)
 
 # plot Čech 2-skeleton atop balls
 ggplot(d, aes(x = x, y = y)) +
   theme_bw() +
   coord_fixed() +
-  stat_disk(radius = .35, fill = "aquamarine3") +
-  stat_cech2(diameter = .7, fill = "darkgoldenrod") +
-  stat_cech1(diameter = .7, size = .2) +
+  stat_disk(radius = r, fill = "aquamarine3") +
+  stat_cech2(diameter = 2*r, fill = "darkgoldenrod") +
+  stat_cech1(diameter = 2*r, size = .2) +
   stat_cech0(size = .3)
 }
 \references{

--- a/tests/testthat/test-simplicial-complex.R
+++ b/tests/testthat/test-simplicial-complex.R
@@ -6,7 +6,7 @@ test_that("Proximate functions work as expected on equilateral triangle", {
   # equilateral triangle
   et <- data.frame(x = cos(2*pi*c(0,1/3,2/3)), y = sin(2*pi*c(0,1/3,2/3)))
   # small perturbations from key values
-  eps <- .01
+  eps <- .00000001
   
   # proximate pairs at diameter ~ sqrt(3)
   expect_equal(nrow(proximate_pairs(et, diameter = sqrt(3) - eps)), 0L)

--- a/tests/testthat/test-simplicial-complex.R
+++ b/tests/testthat/test-simplicial-complex.R
@@ -9,12 +9,12 @@ test_that("Proximate functions work as expected on equilateral triangle", {
   eps <- .01
   
   # proximate pairs at diameter ~ sqrt(3)
-  expect_equal(nrow(proximate_pairs(et, diameter = sqrt(3) - eps)), 0)
-  expect_equal(nrow(proximate_pairs(et, diameter = sqrt(3) + eps)), 3)
+  expect_equal(nrow(proximate_pairs(et, diameter = sqrt(3) - eps)), 0L)
+  expect_equal(nrow(proximate_pairs(et, diameter = sqrt(3) + eps)), 3L)
   
-  # proximate triples at diameter ~ sqrt(3)
-  expect_equal(nrow(proximate_triples(et, diameter = sqrt(3) - eps)), 0)
-  expect_equal(nrow(proximate_triples(et, diameter = sqrt(3) + eps)), 1)
+  # proximate triples at diameter ~ 2
+  expect_equal(nrow(proximate_triples(et, diameter = 2 - eps)), 0L)
+  expect_equal(nrow(proximate_triples(et, diameter = 2 + eps)), 1L)
 })
 
 test_that("Vietoris-Rips distance calculations run as expected", {
@@ -78,7 +78,7 @@ test_that("Cech layers work as expected", {
   expect_is(p1, "ggplot")
   expect_is(p1$layer[[1]], "ggproto")
   expect_equal(c(p1$labels$x, p1$labels$y), c("x", "y"))
-  expect_equal(nrow(layer_data(p1)), 1097)
+  expect_equal(nrow(layer_data(p1)), 1097L)
   
   # Čech 2-skeleton stat
   p2 <- ggplot(d, aes(x = x, y = y)) +
@@ -86,7 +86,7 @@ test_that("Cech layers work as expected", {
   expect_is(p2, "ggplot")
   expect_is(p2$layer[[1]], "ggproto")
   expect_equal(c(p2$labels$x, p2$labels$y), c("x", "y"))
-  expect_equal(nrow(layer_data(p2)), 12651)
+  expect_equal(nrow(layer_data(p2)), 16953L)
   
   # skip on continuous integration services
   skip_on_travis()

--- a/vignettes/phom.Rmd
+++ b/vignettes/phom.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Visualizing persistent homology with ggtda"
 author: "J. Cory Brunson, Raoul R. Wadhwa, Jacob G. Scott"
-date: "1 January 2020"
+date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Visualizing persistent homology with ggtda}

--- a/vignettes/simplicial.Rmd
+++ b/vignettes/simplicial.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Visualizing a simplicial complex with ggtda"
 author: "J. Cory Brunson, Raoul R. Wadhwa, Jacob G. Scott"
-date: "1 January 2020"
+date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Visualizing a simplicial complex with ggtda}


### PR DESCRIPTION
The Čech 2-complex stat (`stat_cech2()`) is corrected from its earlier miscalculated form. The problem lay in the internal function `proximate_triples()`. The examples and tests are updated to reflect the correction.

I don't expect this to conflict with other branches in progress, but i thought it was substantive enough to warrant a separate branch.

Sorry about that! Thanks for the prompt to get back to this.