### PR TITLE
split pareto_persistence into separate testable functions

### DIFF
--- a/R/persistence.r
+++ b/R/persistence.r
@@ -52,9 +52,6 @@
 #'   a string to override the default.
 #' @param diagram One of `"flat"`, `"diagonal"`, or `"landscape"`; the
 #'   orientation for the diagram should take
-#' @param .use_rPref Logical; make explicit whether to use the *rPref* package
-#'   to compute pareto frontiers. if `TRUE` but the package is unavailable, a
-#'   warning is printed.
 #' @example inst/examples/ex-persistence.R
 
 #' @rdname persistence
@@ -121,7 +118,6 @@ stat_frontier <- function(mapping = NULL,
                           na.rm = FALSE,
                           show.legend = NA,
                           inherit.aes = TRUE,
-                          .use_rPref = NA,
                           ...) {
   layer(
     stat = StatFrontier,
@@ -133,7 +129,6 @@ stat_frontier <- function(mapping = NULL,
     inherit.aes = inherit.aes,
     params = list(
       diagram = diagram,
-      .use_rPref = .use_rPref,
       na.rm = na.rm,
       ...
     )
@@ -149,15 +144,14 @@ StatFrontier <- ggproto(
   required_aes = c("start", "end"),
   
   compute_group = function(data, scales,
-                           diagram = "diagonal",
-                           .use_rPref = NA) {
+                           diagram = "diagonal") {
     
     # first row (for aesthetics)
     first_row <- data[1, setdiff(names(data), c("start", "end")), drop = FALSE]
     rownames(first_row) <- NULL
     
     # Pareto frontier
-    data <- pareto_persistence(data, .use_rPref = .use_rPref)
+    data <- pareto_persistence(data)
     data <- data[order(data$start), ]
     if (! all(data$end == cummax(data$end))) {
       warning("`start` and `end` are not anti-sorted.")
@@ -200,18 +194,19 @@ diagram_transform <- function(data, diagram) {
   )
 }
 
-pareto_persistence <- function(data, .use_rPref = NA) {
-  .use_rPref <- as.logical(.use_rPref)
-  if (! isFALSE(.use_rPref) &&
-      "rPref" %in% rownames(utils::installed.packages())) {
-    return(rPref::psel(data, rPref::low("start") * rPref::high("end")))
+pareto_persistence <- function(data) {
+  if ("rPref" %in% rownames(utils::installed.packages())) {
+    pareto_persistence_rPref(data)
   } else {
-    if (isTRUE(.use_rPref)) {
-      warning("Package 'rPref' is unavailable; ",
-              "using base R to compute Pareto frontier.",
-              immediate. = TRUE)
-    }
-    pd <- data[order(data$start, -data$end), ]
-    return(pd[! duplicated(cummax(pd$end)), ])
+    pareto_persistence_base(data)
   }
+}
+
+pareto_persistence_base <- function(data) {
+  pd <- data[order(data$start, -data$end), ]
+  pd[! duplicated(cummax(pd$end)), ]
+}
+
+pareto_persistence_rPref <- function(data) {
+  rPref::psel(data, rPref::low("start") * rPref::high("end"))
 }

--- a/man/persistence.Rd
+++ b/man/persistence.Rd
@@ -27,7 +27,6 @@ stat_frontier(
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE,
-  .use_rPref = NA,
   ...
 )
 }
@@ -78,10 +77,6 @@ that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
 \item{...}{Additional arguments passed to \code{\link[ggplot2:layer]{ggplot2::layer()}}.}
-
-\item{.use_rPref}{Logical; make explicit whether to use the \emph{rPref} package
-to compute pareto frontiers. if \code{TRUE} but the package is unavailable, a
-warning is printed.}
 }
 \description{
 Visualize persistence data in a (flat, diagonal, or landscape)

--- a/tests/testthat/test-persistence.R
+++ b/tests/testthat/test-persistence.R
@@ -7,25 +7,18 @@ d <- subset(mtcars, select = c(mpg, hp))
 names(d) <- c("start", "end")
 
 test_that("pareto calculations work on 'mtcars' data not using rPref", {
-  skip_if("rPref" %in% rownames(utils::installed.packages()))
-  
-  # uses to base R calculation with no message
-  expect_equal(rownames(pareto_persistence(d)),
+  expect_equal(rownames(pareto_persistence_base(d)),
                rownames(d)[c(16L, 24L, 31L)])
-  
-  # throw warning if rPref is explicitly requested
-  expect_warning(rownames(pareto_persistence(d, .use_rPref = TRUE)), "rPref")
 })
 
 test_that("pareto calculations work on 'mtcars' data using rPref", {
   skip_if_not_installed("rPref")
-  
-  # uses rPref
-  expect_equal(rownames(pareto_persistence(d)),
+  expect_equal(rownames(pareto_persistence_rPref(d)),
                rownames(d)[c(16L, 24L, 31L)])
-  
-  # gives same result using base R calculation
-  expect_equal(rownames(pareto_persistence(d, .use_rPref = FALSE)),
+})
+
+test_that("pareto calculations are obtained via conditional function", {
+  expect_equal(rownames(pareto_persistence(d)),
                rownames(d)[c(16L, 24L, 31L)])
 })
 


### PR DESCRIPTION
> fix(pareto_persistence): rm rPref param, write & test base & rPref functions
> 
> NOTE: Instead of using the additional .use_rPref parameter, this commit splits
> the pareto_persistence function into a base calculator and an rPref calculator,
> with the original calling one or the other according as rPref is installed.
> This restores the pre-parameter behavior elsewhere and allows both calculator
> functions to be tested (provided rPref is installed).

I personally think this solution is better. We don't need 100% coverage, and this commit allows coverage of both pareto calculators without making the underlying code too strange.

This is a sub-branch of `coverage`, so the PR is directed there. Accepting both PRs will (theoretically) end with this commit in `main`.