### PR TITLE
fix(diagonal): require unique aesthetic vaules only within panel

### DIFF
--- a/R/persistence.r
+++ b/R/persistence.r
@@ -356,10 +356,12 @@ GeomDiagonal <- ggproto(
   setup_data = function(data, params) {
     
     # keep only columns that are constant throughout the data
-    data <- dplyr::select_if(
-      data,
-      function(x) length(unique(x)) == 1L
-    )[1L, , drop = FALSE]
+    data <- aggregate(
+      data[, setdiff(names(data), "PANEL"), drop = FALSE],
+      by = data[, "PANEL", drop = FALSE],
+      function(x) if (length(unique(x)) == 1L) unique(x) else NA
+    )
+    data[] <- lapply(data, function(x) if (all(is.na(x))) NULL else x)
     rownames(data) <- NULL
     
     data


### PR DESCRIPTION
I tried faceting some persistence diagrams and found that the diagonal geom failed to account for the internal `PANEL` variable used for this purpose. This fix works for my examples (and reduces the dependency on dplyr), but @rrrlw i wanted to run it by you in case you have some other examples using the diagonal geom that would be worth checking. Thanks!